### PR TITLE
Add 100millis sleep to loops - consume fewer system resources

### DIFF
--- a/src/bin/client.rs
+++ b/src/bin/client.rs
@@ -412,6 +412,7 @@ impl Controller {
 					error!(LOGGER, "Mining Controller Error {:?}", e);
 				}
 			}
+			thread::sleep(std::time::Duration::from_millis(100));
 		} // loop
 	}
 }

--- a/src/bin/grin_miner.rs
+++ b/src/bin/grin_miner.rs
@@ -172,5 +172,6 @@ fn main() {
 			thread::sleep(std::time::Duration::from_millis(100));
 			break;
 		}
+		thread::sleep(std::time::Duration::from_millis(100));
 	}
 }

--- a/src/bin/mining.rs
+++ b/src/bin/mining.rs
@@ -18,6 +18,7 @@
 
 use std::sync::{mpsc, Arc, RwLock};
 use time;
+use std::{self, thread};
 use util::LOGGER;
 use config;
 use stats;
@@ -112,6 +113,7 @@ impl Controller {
 					sol.solution_nonces.to_vec(),
 				));
 			}
+			thread::sleep(std::time::Duration::from_millis(100));
 		}
 	}
 


### PR DESCRIPTION

This was first reported in the gitter grin lobby.  


Without these thread yields I saw:
```
218% CPU when not mining
~0.119 GPS when mining
```

After adding 100 milisecond sleeps to three loops I see:
```
14% CPU when not mining
~0.152 GPS when mining
```
