### PR TITLE
FIX: Segmentation fault on macOS Sierra and High Sierra

### DIFF
--- a/src/bin/mining.rs
+++ b/src/bin/mining.rs
@@ -74,12 +74,10 @@ impl Controller {
 
 		loop {
 			while let Some(message) = self.rx.try_iter().next() {
-				debug!(LOGGER, "Miner recieved message: {:?}", message);
+				debug!(LOGGER, "Miner received message: {:?}", message);
 				let result = match message {
 					types::MinerMessage::ReceivedJob(height, diff, pre_pow) => {
-						if self.job_handle.is_some() {
-							self.job_handle.as_mut().unwrap().stop_jobs();
-						}
+						self.stop_job();
 						self.current_height = height;
 						self.current_network_diff = diff;
 						self.start_job(30, &pre_pow)

--- a/util/Cargo.toml
+++ b/util/Cargo.toml
@@ -18,7 +18,7 @@ slog-async = "2.1"
 
 [dependencies.cuckoo_miner]
 git = "https://github.com/mimblewimble/cuckoo-miner"
-tag = "grin_integration_25"
+#tag = "grin_integration_25"
 #uncomment this feature to enable cuda builds (cuda toolkit must be installed)
 #features=["build-cuda-plugins"]
 


### PR DESCRIPTION
1. Fix issue #2 in [dependencies.cuckoo_miner] (on its submodule:cuckoo):  Segmentation fault on macOS Sierra and High Sierra. 
Related cuckoo repo pull request [#2](https://github.com/mimblewimble/cuckoo/pull/2) and cuckoo_miner repo pull request [#17](https://github.com/mimblewimble/cuckoo-miner/pull/17). 
Before this fixing, the "*Segmentation fault*" problem happen frequently. With this fixing, I test on two mac computers, running *grin-miner* mining for over 4 hours, one use "*mean_compat_cpu*" type_filter and another use "*mean_cpu*" type_filter, 19 blocks mined successfully, no more "*Segmentation fault*".

2. A minor improvement to replace a piece of codes with stop_job() function call.