### PR TITLE
Resolve rust 1.30.0 deprecation messages; fix a typo in log messages

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.3.0"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
 publish = false
 build = "src/build/build.rs"
+autobins = false
 
 [workspace]
 members = ["config", "util"]

--- a/config/Cargo.toml
+++ b/config/Cargo.toml
@@ -9,5 +9,6 @@ publish = false
 serde = "1"
 serde_derive = "1"
 toml = "0.4"
+dirs = "1.0"
 
 grin_miner_util = { path = "../util" }

--- a/config/src/config.rs
+++ b/config/src/config.rs
@@ -24,6 +24,8 @@ use types::MinerConfig;
 use util::LoggingConfig;
 use types::{ConfigError, ConfigMembers, GlobalConfig};
 
+extern crate dirs;
+
 /// The default file name to use when trying to derive
 /// the config file location
 
@@ -72,7 +74,7 @@ impl GlobalConfig {
 			return Ok(());
 		}
 		// Then look in {user_home}/.grin
-		let config_path = env::home_dir();
+		let config_path = dirs::home_dir();
 		if let Some(mut p) = config_path {
 			p.push(GRIN_HOME);
 			p.push(CONFIG_FILE_NAME);

--- a/src/bin/client.rs
+++ b/src/bin/client.rs
@@ -460,7 +460,7 @@ impl Controller {
 
 			// Talk to the cuckoo miner plugin
 			while let Some(message) = self.rx.try_iter().next() {
-				debug!(LOGGER, "Client recieved message: {:?}", message);
+				debug!(LOGGER, "Client received message: {:?}", message);
 				let result = match message {
 					types::ClientMessage::FoundSolution(height, job_id, nonce, pow) => {
 						self.send_message_submit(height, job_id, nonce, pow)

--- a/src/bin/stats.rs
+++ b/src/bin/stats.rs
@@ -56,7 +56,7 @@ pub struct ClientStats {
 	pub connection_status: String,
 	/// Last message sent to server
 	pub last_message_sent: String,
-	/// Last response/command recieved from server
+	/// Last response/command received from server
 	pub last_message_received: String,
 }
 


### PR DESCRIPTION
Rust 1.30.0 warns about env::home_dir(), replaced with dirs::home_dir()
It also warns about bin building behavior changing, set autobins to false
Lastly, log messages spelled "received" as "recieved", fixed