### PR TITLE
fix: cpuload 100% on loop try_iter 

### DIFF
--- a/cuckoo-miner/src/miner/miner.rs
+++ b/cuckoo-miner/src/miner/miner.rs
@@ -94,16 +94,19 @@ impl CuckooMiner {
 		let control_ctx = SolverCtxWrapper(NonNull::new(ctx).unwrap());
 
 		let stop_fn = solver.lib.get_stop_solver_instance();
-		// monitor whether to send a stop signal to the solver, which should
-		// end the current solve attempt below
-		let stop_handle = thread::spawn(move || loop {
-			let ctx_ptr = control_ctx.0.as_ptr();
+
+		let mut iter_count = 0;
+		let mut paused = true;
+		let ctx_ptr = control_ctx.0.as_ptr();
+		'solver_loop: loop {
+			// monitor whether to send a stop signal to the solver, which should
+			// end the current solve attempt below
 			while let Some(message) = control_rx.try_iter().next() {
 				debug!(LOGGER, "solver_thread - control_rx got msg: {:?}", message);
 				match message {
 					ControlMessage::Stop => {
 						PluginLibrary::stop_solver_from_instance(stop_fn.clone(), ctx_ptr);
-						return;
+						break 'solver_loop;
 					}
 					ControlMessage::Pause => {
 						PluginLibrary::stop_solver_from_instance(stop_fn.clone(), ctx_ptr);
@@ -111,12 +114,7 @@ impl CuckooMiner {
 					_ => {}
 				};
 			}
-			thread::sleep(time::Duration::from_micros(100));
-		});
 
-		let mut iter_count = 0;
-		let mut paused = true;
-		loop {
 			if let Some(message) = solver_loop_rx.try_iter().next() {
 				debug!(LOGGER, "solver_thread - solver_loop_rx got msg: {:?}", message);
 				match message {
@@ -175,7 +173,6 @@ impl CuckooMiner {
 			thread::sleep(time::Duration::from_micros(100));
 		}
 
-		let _ = stop_handle.join();
 		solver.lib.destroy_solver_ctx(ctx);
 		solver.lib.unload();
 		let _ = solver_stopped_tx.send(ControlMessage::SolverStopped(instance));

--- a/cuckoo-miner/src/miner/miner.rs
+++ b/cuckoo-miner/src/miner/miner.rs
@@ -94,7 +94,6 @@ impl CuckooMiner {
 		let control_ctx = SolverCtxWrapper(NonNull::new(ctx).unwrap());
 
 		let stop_fn = solver.lib.get_stop_solver_instance();
-		let sleep_dur = time::Duration::from_millis(100);
 		// monitor whether to send a stop signal to the solver, which should
 		// end the current solve attempt below
 		let stop_handle = thread::spawn(move || loop {
@@ -112,7 +111,7 @@ impl CuckooMiner {
 					_ => {}
 				};
 			}
-			thread::sleep(std::time::Duration::from_micros(100));
+			thread::yield_now();
 		});
 
 		let mut iter_count = 0;
@@ -124,13 +123,11 @@ impl CuckooMiner {
 					ControlMessage::Stop => break,
 					ControlMessage::Pause => paused = true,
 					ControlMessage::Resume => paused = false,
-					_ => {
-						info!(LOGGER, "solver_thread - solver_loop_rx got other msg: {:?}", message);
-					}
+					_ => {}
 				}
 			}
 			if paused {
-				thread::sleep(sleep_dur);
+				thread::yield_now();
 				continue;
 			}
 			{
@@ -175,7 +172,7 @@ impl CuckooMiner {
 				}
 			}
 			solver.solutions = SolverSolutions::default();
-			thread::sleep(std::time::Duration::from_millis(10));
+			thread::yield_now();
 		}
 
 		let _ = stop_handle.join();

--- a/cuckoo-miner/src/miner/miner.rs
+++ b/cuckoo-miner/src/miner/miner.rs
@@ -111,7 +111,7 @@ impl CuckooMiner {
 					_ => {}
 				};
 			}
-			thread::yield_now();
+			thread::sleep(time::Duration::from_micros(100));
 		});
 
 		let mut iter_count = 0;

--- a/cuckoo-miner/src/miner/miner.rs
+++ b/cuckoo-miner/src/miner/miner.rs
@@ -127,7 +127,7 @@ impl CuckooMiner {
 				}
 			}
 			if paused {
-				thread::yield_now();
+				thread::sleep(time::Duration::from_micros(100));
 				continue;
 			}
 			{
@@ -172,7 +172,7 @@ impl CuckooMiner {
 				}
 			}
 			solver.solutions = SolverSolutions::default();
-			thread::yield_now();
+			thread::sleep(time::Duration::from_micros(100));
 		}
 
 		let _ = stop_handle.join();

--- a/cuckoo-miner/src/miner/miner.rs
+++ b/cuckoo-miner/src/miner/miner.rs
@@ -110,6 +110,7 @@ impl CuckooMiner {
 					}
 					_ => {}
 				};
+				thread::sleep(std::time::Duration::from_millis(100));
 			}
 		});
 
@@ -170,6 +171,7 @@ impl CuckooMiner {
 				}
 			}
 			solver.solutions = SolverSolutions::default();
+			thread::sleep(std::time::Duration::from_millis(10));
 		}
 
 		let _ = stop_handle.join();

--- a/cuckoo-miner/src/miner/miner.rs
+++ b/cuckoo-miner/src/miner/miner.rs
@@ -109,12 +109,10 @@ impl CuckooMiner {
 					ControlMessage::Pause => {
 						PluginLibrary::stop_solver_from_instance(stop_fn.clone(), ctx_ptr);
 					}
-					_ => {
-						info!(LOGGER, "solver_thread - control_rx got other msg: {:?}", message);
-					}
+					_ => {}
 				};
 			}
-			thread::sleep(std::time::Duration::from_millis(100));
+			thread::sleep(std::time::Duration::from_micros(100));
 		});
 
 		let mut iter_count = 0;

--- a/src/bin/client.rs
+++ b/src/bin/client.rs
@@ -573,7 +573,7 @@ impl Controller {
 					self.stream = None;
 				}
 			}
-			thread::sleep(std::time::Duration::from_millis(100));
+			thread::sleep(std::time::Duration::from_millis(10));
 		} // loop
 	}
 }

--- a/src/bin/tui/ui.rs
+++ b/src/bin/tui/ui.rs
@@ -15,6 +15,7 @@
 //! Basic TUI to better output the overall system status and status
 //! of various subsystems
 
+use std::{self, thread};
 use std::sync::{mpsc, Arc, RwLock};
 use time;
 
@@ -176,6 +177,7 @@ impl Controller {
 				self.ui.ui_tx.send(UIMessage::UpdateStatus(stats.clone())).unwrap();
 				next_stat_update = time::get_time().sec + stat_update_interval;
 			}
+			thread::sleep(std::time::Duration::from_millis(100));
 		}
 	}
 }


### PR DESCRIPTION
Use tool oprofile to analyze the grin-miner, I got this:
```
samples  %        image name               symbol name
889800   45.4459  grin-miner               <sync::mpsc::TryIter<'a, T> as core::iter::iterator::Iterator>::next
469984   24.0041  grin-miner               <sync::mpsc::stream::Packet<T>>::try_recv
338392   17.2831  grin-miner               <sync::mpsc::spsc_queue::Queue<T, ProducerAddition, ConsumerAddition>>::pop
```
which shows a heavy mspc try_iter calling.
And find the root cause is there's no any sleep in the control_rx while loop:
```
while let Some(message) = control_rx.try_iter().next() {
...
```
The fix solution can be just add 1us sleep in this while loop, but I more prefer to merge this thread with the main `solver_thread`.

