### PR TITLE
Fix solver stop and CPU load (again)

### DIFF
--- a/cuckoo-miner/src/miner/miner.rs
+++ b/cuckoo-miner/src/miner/miner.rs
@@ -99,7 +99,7 @@ impl CuckooMiner {
 		// end the current solve attempt below
 		let stop_handle = thread::spawn(move || loop {
 			let ctx_ptr = control_ctx.0.as_ptr();
-			while let Some(message) = control_rx.try_iter().next() {
+			while let Some(message) = control_rx.iter().next() {
 				match message {
 					ControlMessage::Stop => {
 						PluginLibrary::stop_solver_from_instance(stop_fn.clone(), ctx_ptr);

--- a/src/bin/client.rs
+++ b/src/bin/client.rs
@@ -580,7 +580,7 @@ impl Controller {
 					self.stream = None;
 				}
 			}
-			thread::sleep(std::time::Duration::from_millis(10));
+			thread::sleep(std::time::Duration::from_millis(100));
 		} // loop
 	}
 }

--- a/src/bin/tui/ui.rs
+++ b/src/bin/tui/ui.rs
@@ -15,7 +15,6 @@
 //! Basic TUI to better output the overall system status and status
 //! of various subsystems
 
-use std::{self, thread};
 use std::sync::{mpsc, Arc, RwLock};
 use time;
 
@@ -177,7 +176,6 @@ impl Controller {
 				self.ui.ui_tx.send(UIMessage::UpdateStatus(stats.clone())).unwrap();
 				next_stat_update = time::get_time().sec + stat_update_interval;
 			}
-			thread::sleep(std::time::Duration::from_millis(100));
 		}
 	}
 }


### PR DESCRIPTION
This pr reverts the removal of a control thread for the current solving attempt and fixes CPU load issue in this thread.

We still need an additional thread because we need to be able to stop the current solving attempt, which we can't do from the same thread. So we check the control messages before running the solver instead of doing it in parallel as we should.

At the same time we should use blocking read from the channel in the control thread, so the real fix (obscured by revert) is `s/control_rx.try_iter()/control_rx.iter()/`