### PR TITLE
solution getting in mining thread sleep 0.1ms instead of 100ms

### DIFF
--- a/src/bin/mining.rs
+++ b/src/bin/mining.rs
@@ -118,7 +118,7 @@ impl Controller {
 				let mut s_stats = self.stats.write().unwrap();
 				s_stats.mining_stats.solution_stats.num_solutions_found += ss.num_sols;
 			}
-			thread::sleep(std::time::Duration::from_millis(100));
+			thread::sleep(std::time::Duration::from_micros(100));
 		}
 	}
 


### PR DESCRIPTION
It doesn't make sense to sleep 100ms here to get minded solution(s) from shared_data, I prefer 100us instead.

Actually, currently the procedure seems a little bit too complex: the solutions is put into shared_data in `solver_thread`, and then this `mining` thread getting these solutions (by polling the shared_data) and send message to next thread `client`, and finally the thread `client` query these messages and call `send_message_submit` for the real submitting to server.

I would like to give another PR to simply this procedure, and try to directly call `send_message_submit`  once a solution is found by `run_solver`.
