### PR TITLE
Fix: Rename crate grin-miner to grin_miner

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -367,7 +367,7 @@ version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "grin-miner"
+name = "grin_miner"
 version = "0.5.0"
 dependencies = [
  "backtrace 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "grin-miner"
+name = "grin_miner"
 version = "0.5.0"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
 description = "Mining software for Grin, supports CPU and CUDA GPUs."


### PR DESCRIPTION
My first contribution! :grin: 

This change appears to be pretty straightforward, however here are 2 questions/ complications that I thought of: 

- Do we also remove the hyphen from the configurations files (grin-miner.toml), executable name, or repository name? I'm guessing not, but want to make sure.
 
- I looked into how cargo will handle the name change, and it seems like Crates.io will treat grin-miner and grin_miner as the same package, but if other projects include grin-miner as a dependency, the name change will break their projects. Do we know of any other projects where there this needs to be updated ? 