### PR TITLE
Show login error to user instead of crashing

### DIFF
--- a/src/bin/client.rs
+++ b/src/bin/client.rs
@@ -453,8 +453,11 @@ impl Controller {
 				} else {
 					// This is a fatal error
 					let err = res.error.unwrap();
+					let mut stats = self.stats.write().unwrap();
+					stats.client_stats.last_message_received = format!("Last Message Received: Failed to log in: {:?}", err);
+					stats.client_stats.connection_status = "Connection Status: Server requires login".to_string();
+					stats.client_stats.connected = false;
 					error!(LOGGER, "Failed to log in: {:?}", err);
-					panic!("Failed to log in to stratum server: {:?}", err);
 				}
 			}
 			// unknown method response


### PR DESCRIPTION
When the `login` message returns an error the miner stops working, but the error message is only sent to the logfile.

This PR changes the logic, now the fact that the server requires authentication is mentioned in the Connection Status.

(Yes, this is far from perfect, but IMHO much better than the current state)