### PR TITLE
Rolling average of total GPS

### DIFF
--- a/src/bin/mining.rs
+++ b/src/bin/mining.rs
@@ -169,7 +169,7 @@ impl Controller {
 
 		if sps_total.is_finite() {
 			let mut s_stats = self.stats.write().unwrap();
-			s_stats.mining_stats.combined_gps = sps_total;
+			s_stats.mining_stats.add_combined_gps(sps_total);
 			s_stats.mining_stats.target_difficulty = self.current_target_diff;
 			s_stats.mining_stats.block_height = self.current_height;
 			s_stats.mining_stats.device_stats = stats;

--- a/src/bin/stats.rs
+++ b/src/bin/stats.rs
@@ -17,8 +17,8 @@
 
 /// Struct to return relevant information about the mining process
 /// back to interested callers (such as the TUI)
-use plugin;
 
+use plugin;
 
 #[derive(Clone)]
 pub struct SolutionStats {
@@ -49,7 +49,7 @@ impl Default for SolutionStats {
 #[derive(Clone)]
 pub struct MiningStats {
 	/// combined graphs per second
-	pub combined_gps: f64,
+	combined_gps: Vec<f64>,
 	/// what block height we're mining at
 	pub block_height: u64,
 	/// current target for share difficulty we're working on
@@ -63,11 +63,27 @@ pub struct MiningStats {
 impl Default for MiningStats {
 	fn default() -> MiningStats {
 		MiningStats {
-			combined_gps: 0.0,
+			combined_gps: vec![],
 			block_height: 0,
 			target_difficulty: 0,
 			solution_stats: SolutionStats::default(),
 			device_stats: vec![],
+		}
+	}
+}
+
+impl MiningStats {
+	pub fn add_combined_gps(&mut self, val: f64) {
+		self.combined_gps.insert(0, val);
+		self.combined_gps.truncate(50);
+	}
+
+	pub fn combined_gps(&self) -> f64 {
+		if self.combined_gps.is_empty() {
+			0.0
+		} else {
+			let sum: f64 = self.combined_gps.iter().sum();
+			sum / (self.combined_gps.len() as f64)
 		}
 	}
 }

--- a/src/bin/tui/mining.rs
+++ b/src/bin/tui/mining.rs
@@ -170,7 +170,7 @@ impl TUIStatusListener for TUIMiningView {
 
 		let (basic_mining_status, basic_network_info) = {
 			if client_stats.connected {
-				if mining_stats.combined_gps == 0.0 {
+				if mining_stats.combined_gps() == 0.0 {
 					(
 						"Mining Status: Starting miner and awaiting first graph time..."
 							.to_string(),
@@ -180,7 +180,7 @@ impl TUIStatusListener for TUIMiningView {
 					(
 						format!(
 							"Mining Status: Mining at height {} at {:.*} GPS",
-							mining_stats.block_height, 4, mining_stats.combined_gps
+							mining_stats.block_height, 4, mining_stats.combined_gps()
 						),
 						format!(
 							"Cuck(at)oo - Target Share Difficulty {}",


### PR DESCRIPTION
Figured it was about time I make a PR against this repo. And I was getting tired of the total bouncing up and down when I have more than one card in.

This keeps a 50-values moving average of total GPS as reported by all plugins.