### PR TITLE
Re-enable mining plugin dir configuration

### DIFF
--- a/config/src/config.rs
+++ b/config/src/config.rs
@@ -65,11 +65,47 @@ fn resolve_param(config: &mut PluginConfig, name: &str, value: u32) {
 
 /// Transforms a set of grin-miner plugin configs to cuckoo-miner plugins configs
 pub fn read_configs(
+	plugin_dir: Option<PathBuf>,
 	conf_in: Vec<GrinMinerPluginConfig>,
 ) -> Result<Vec<PluginConfig>, CuckooMinerError> {
+	// Resolve a final plugin path, either config-provided or from the current executable path
+	let plugin_dir_absolute_path = match plugin_dir {
+		Some(path) => {
+			let absolute_path = path.canonicalize().map_err(CuckooMinerError::from);
+			if let Ok(path) = &absolute_path {
+				debug!(
+					LOGGER,
+					"Using mining plugin dir provided by config: {:?}", path
+				);
+			};
+			absolute_path
+		}
+		None => {
+			let absolute_path =
+				env::current_exe()
+					.map_err(CuckooMinerError::from)
+					.map(|mut env_path| {
+						env_path.pop();
+						// cargo test exes are a directory further down
+						if env_path.ends_with("deps") {
+							env_path.pop();
+						}
+						env_path.push("plugins");
+						env_path
+					});
+			if let Ok(path) = &absolute_path {
+				debug!(
+					LOGGER,
+					"No mining plugin dir provided by config. Using default plugin dir: {:?}", path
+				);
+			};
+			absolute_path
+		}
+	}?;
+
 	let mut return_vec = vec![];
 	for conf in conf_in {
-		let res = PluginConfig::new(&conf.plugin_name);
+		let res = PluginConfig::new(plugin_dir_absolute_path.clone(), &conf.plugin_name);
 		match res {
 			Err(e) => {
 				error!(LOGGER, "Error reading plugin config: {:?}", e);

--- a/config/src/types.rs
+++ b/config/src/types.rs
@@ -104,7 +104,7 @@ pub struct MinerConfig {
 	pub stratum_server_tls_enabled: Option<bool>,
 
 	/// plugin dir
-	pub miner_plugin_dir: Option<String>,
+	pub miner_plugin_dir: Option<PathBuf>,
 
 	/// Cuckoo miner plugin configuration, one for each plugin
 	pub miner_plugin_config: Vec<GrinMinerPluginConfig>,

--- a/cuckoo-miner/src/miner/types.rs
+++ b/cuckoo-miner/src/miner/types.rs
@@ -13,10 +13,8 @@
 // limitations under the License.
 
 //! Miner types
-use std::env;
 use std::sync::{Arc, RwLock};
 
-use config::types::SO_SUFFIX;
 use plugin::{SolverSolutions, SolverStats};
 use CuckooMinerError;
 use {PluginConfig, PluginLibrary};
@@ -39,15 +37,7 @@ pub struct SolverInstance {
 impl SolverInstance {
 	/// Create a new solver instance with the given config
 	pub fn new(config: PluginConfig) -> Result<SolverInstance, CuckooMinerError> {
-		let mut p_path = env::current_exe().unwrap();
-		p_path.pop();
-		// cargo test exes are a directory further down
-		if p_path.ends_with("deps") {
-			p_path.pop();
-		}
-		p_path.push("plugins");
-		p_path.push(format!("{}{}", config.name, SO_SUFFIX).as_str());
-		let l = PluginLibrary::new(p_path.to_str().unwrap())?;
+		let l = PluginLibrary::new(&config.file)?;
 		Ok(SolverInstance {
 			lib: l,
 			config: config,

--- a/cuckoo-miner/tests/common/mod.rs
+++ b/cuckoo-miner/tests/common/mod.rs
@@ -20,6 +20,8 @@ extern crate cuckoo_miner as cuckoo;
 extern crate time;
 
 use std;
+use std::env;
+use std::path::PathBuf;
 use self::cuckoo::{CuckooMiner, PluginConfig};
 
 /// Values from T4 genesis that should be validated
@@ -39,6 +41,21 @@ pub const T4_GENESIS_PROOF:[u64; 42] = [
 0x1542d236, 0x155f2df0, 0x1577394e, 0x163c3513, 0x19349845, 0x19d46953, 0x19f65ed4,
 0x1a0411b9, 0x1a2fa039, 0x1a72a06c, 0x1b02ddd2, 0x1b594d59, 0x1b7bffd3, 0x1befe12e,
 0x1c82e4cd, 0x1d492478, 0x1de132a5, 0x1e578b3c, 0x1ed96855, 0x1f222896, 0x1fea0da6];
+
+// Helper function, derives the plugin directory for mining tests
+pub fn mining_plugin_dir_for_tests() -> PathBuf {
+	env::current_exe()
+		.map(|mut env_path| {
+			env_path.pop();
+			// cargo test exes are a directory further down
+			if env_path.ends_with("deps") {
+				env_path.pop();
+			}
+			env_path.push("plugins");
+			env_path
+		})
+		.unwrap()
+}
 
 // Helper function, tests a particular miner implementation against a known set
 pub fn mine_async_for_duration(configs: &Vec<PluginConfig>, duration_in_seconds: i64) {
@@ -113,7 +130,7 @@ pub fn mine_async_for_duration(configs: &Vec<PluginConfig>, duration_in_seconds:
 				miner.stop_solvers();
 				return;
 			}
-			//avoid busy wait 
+			//avoid busy wait
 			let sleep_dur = std::time::Duration::from_millis(100);
 			std::thread::sleep(sleep_dur);
 			if stats_updated && extra_time {

--- a/cuckoo-miner/tests/miner.rs
+++ b/cuckoo-miner/tests/miner.rs
@@ -20,12 +20,12 @@ extern crate rand;
 extern crate cuckoo_miner as cuckoo;
 
 use cuckoo::{PluginConfig};
-use common::mine_async_for_duration;
+use common::{mining_plugin_dir_for_tests, mine_async_for_duration};
 
 // AT LEAN ///////////////
 #[test]
 fn mine_cuckatoo_lean_compat_cpu_19() {
-	let mut config = PluginConfig::new("cuckatoo_lean_cpu_compat_19").unwrap();
+	let mut config = PluginConfig::new(mining_plugin_dir_for_tests(), "cuckatoo_lean_cpu_compat_19").unwrap();
 	config.params.nthreads = 4;
 	mine_async_for_duration(&vec![config], 20);
 }
@@ -33,7 +33,7 @@ fn mine_cuckatoo_lean_compat_cpu_19() {
 #[ignore]
 #[test]
 fn mine_cuckatoo_lean_compat_cpu_31() {
-	let mut config = PluginConfig::new("cuckatoo_lean_cpu_compat_31").unwrap();
+	let mut config = PluginConfig::new(mining_plugin_dir_for_tests(), "cuckatoo_lean_cpu_compat_31").unwrap();
 	config.params.nthreads = 4;
 	mine_async_for_duration(&vec![config], 20);
 }
@@ -42,7 +42,7 @@ fn mine_cuckatoo_lean_compat_cpu_31() {
 #[cfg(feature="test-avx2")]
 #[test]
 fn mine_cuckatoo_lean_avx2_cpu_31() {
-	let mut config = PluginConfig::new("cuckatoo_lean_cpu_avx2_31").unwrap();
+	let mut config = PluginConfig::new(mining_plugin_dir_for_tests(), "cuckatoo_lean_cpu_avx2_31").unwrap();
 	config.params.nthreads = 4;
 	mine_async_for_duration(&vec![config], 20);
 }
@@ -51,14 +51,14 @@ fn mine_cuckatoo_lean_avx2_cpu_31() {
 
 #[test]
 fn mine_cuckatoo_mean_cpu_compat_19() {
-	let mut config = PluginConfig::new("cuckatoo_mean_cpu_compat_19").unwrap();
+	let mut config = PluginConfig::new(mining_plugin_dir_for_tests(), "cuckatoo_mean_cpu_compat_19").unwrap();
 	config.params.nthreads = 4;
 	mine_async_for_duration(&vec![config], 20);
 }
 
 #[cfg(feature="test-avx2")]
 fn mine_cuckatoo_mean_avx2_cpu_19() {
-	let mut config = PluginConfig::new("cuckatoo_mean_cpu_avx2_19").unwrap();
+	let mut config = PluginConfig::new(mining_plugin_dir_for_tests(), "cuckatoo_mean_cpu_avx2_19").unwrap();
 	config.params.nthreads = 4;
 	mine_async_for_duration(&vec![config], 20);
 }
@@ -66,7 +66,7 @@ fn mine_cuckatoo_mean_avx2_cpu_19() {
 #[ignore]
 #[test]
 fn mine_cuckatoo_mean_compat_cpu_31() {
-	let mut config = PluginConfig::new("cuckatoo_mean_cpu_compat_31").unwrap();
+	let mut config = PluginConfig::new(mining_plugin_dir_for_tests(), "cuckatoo_mean_cpu_compat_31").unwrap();
 	config.params.nthreads = 4;
 	mine_async_for_duration(&vec![config], 20);
 }
@@ -75,7 +75,7 @@ fn mine_cuckatoo_mean_compat_cpu_31() {
 #[cfg(feature="test-avx2")]
 #[test]
 fn mine_cuckatoo_mean_avx2_cpu_31() {
-	let mut config = PluginConfig::new("cuckatoo_mean_cpu_avx2_31").unwrap();
+	let mut config = PluginConfig::new(mining_plugin_dir_for_tests(), "cuckatoo_mean_cpu_avx2_31").unwrap();
 	config.params.nthreads = 4;
 	mine_async_for_duration(&vec![config], 20);
 }
@@ -84,7 +84,7 @@ fn mine_cuckatoo_mean_avx2_cpu_31() {
 #[cfg(feature="build-cuda-plugins")]
 #[test]
 fn mine_cuckatoo_mean_cuda_19() {
-	let mut config = PluginConfig::new("cuckatoo_mean_cuda_19").unwrap();
+	let mut config = PluginConfig::new(mining_plugin_dir_for_tests(), "cuckatoo_mean_cuda_19").unwrap();
 	mine_async_for_duration(&vec![config], 20);
 }
 
@@ -92,7 +92,7 @@ fn mine_cuckatoo_mean_cuda_19() {
 #[cfg(feature="build-cuda-plugins")]
 #[test]
 fn mine_cuckatoo_mean_cuda_31() {
-	let mut config = PluginConfig::new("cuckatoo_mean_cuda_31").unwrap();
+	let mut config = PluginConfig::new(mining_plugin_dir_for_tests(), "cuckatoo_mean_cuda_31").unwrap();
 	mine_async_for_duration(&vec![config], 20);
 }
 
@@ -100,7 +100,7 @@ fn mine_cuckatoo_mean_cuda_31() {
 #[cfg(feature="build-cuda-plugins")]
 #[test]
 fn mine_cuckatoo_lean_cuda_19() {
-	let mut config = PluginConfig::new("cuckatoo_lean_cuda_19").unwrap();
+	let mut config = PluginConfig::new(mining_plugin_dir_for_tests(), "cuckatoo_lean_cuda_19").unwrap();
 	mine_async_for_duration(&vec![config], 20);
 }
 
@@ -108,7 +108,7 @@ fn mine_cuckatoo_lean_cuda_19() {
 #[cfg(feature="build-cuda-plugins")]
 #[test]
 fn mine_cuckatoo_lean_cuda_31() {
-	let mut config = PluginConfig::new("cuckatoo_lean_cuda_31").unwrap();
+	let mut config = PluginConfig::new(mining_plugin_dir_for_tests(), "cuckatoo_lean_cuda_31").unwrap();
 	mine_async_for_duration(&vec![config], 20);
 }
 
@@ -116,7 +116,7 @@ fn mine_cuckatoo_lean_cuda_31() {
 #[ignore]
 #[test]
 fn mine_cuckaroo_mean_cpu_compat_19() {
-	let mut config = PluginConfig::new("cuckaroo_cpu_compat_19").unwrap();
+	let mut config = PluginConfig::new(mining_plugin_dir_for_tests(), "cuckaroo_cpu_compat_19").unwrap();
 	config.params.nthreads = 4;
 	mine_async_for_duration(&vec![config], 20);
 }
@@ -125,14 +125,14 @@ fn mine_cuckaroo_mean_cpu_compat_19() {
 #[cfg(feature="test-avx2")]
 #[test]
 fn mine_cuckaroo_mean_cpu_avx2_29() {
-	let mut config = PluginConfig::new("cuckaroo_cpu_avx_19").unwrap();
+	let mut config = PluginConfig::new(mining_plugin_dir_for_tests(), "cuckaroo_cpu_avx_19").unwrap();
 	config.params.nthreads = 4;
 	mine_async_for_duration(&vec![config], 20);
 }
 
 #[test]
 fn mine_cuckaroo_mean_cpu_compat_29() {
-	let mut config = PluginConfig::new("cuckaroo_cpu_compat_29").unwrap();
+	let mut config = PluginConfig::new(mining_plugin_dir_for_tests(), "cuckaroo_cpu_compat_29").unwrap();
 	config.params.nthreads = 4;
 	mine_async_for_duration(&vec![config], 20);
 }
@@ -140,7 +140,7 @@ fn mine_cuckaroo_mean_cpu_compat_29() {
 #[cfg(feature="test-avx2")]
 #[test]
 fn mine_cuckaroo_mean_cpu_avx2_29() {
-	let mut config = PluginConfig::new("cuckaroo_cpu_avx_29").unwrap();
+	let mut config = PluginConfig::new(mining_plugin_dir_for_tests(), "cuckaroo_cpu_avx_29").unwrap();
 	config.params.nthreads = 4;
 	mine_async_for_duration(&vec![config], 20);
 }
@@ -148,6 +148,6 @@ fn mine_cuckaroo_mean_cpu_avx2_29() {
 #[cfg(feature="build-cuda-plugins")]
 #[test]
 fn mine_cuckaroo_cuda_29() {
-	let mut config = PluginConfig::new("cuckatoo_cuda_29").unwrap();
+	let mut config = PluginConfig::new(mining_plugin_dir_for_tests(), "cuckatoo_cuda_29").unwrap();
 	mine_async_for_duration(&vec![config], 20);
 }

--- a/src/bin/grin_miner.rs
+++ b/src/bin/grin_miner.rs
@@ -165,7 +165,10 @@ fn main() {
 	// Load plugin configuration and start solvers first,
 	// so we can exit pre-tui if something is obviously wrong
 	debug!(LOGGER, "Starting solvers");
-	let result = config::read_configs(mining_config.miner_plugin_config.clone());
+	let result = config::read_configs(
+		mining_config.miner_plugin_dir.clone(),
+		mining_config.miner_plugin_config.clone()
+        );
 	let mut miner = match result {
 		Ok(cfgs) => cuckoo::CuckooMiner::new(cfgs),
 		Err(e) => {


### PR DESCRIPTION
Addresses issue #111 
Attempts to use the plugin directory specified in the configuration and falls back to the directory of the current binary if omitted. Cleans up a bit of duplicated logic around path parsing