### PR TITLE
Fixing issue with commented out miner_plugin_dir being unaccounted for

### DIFF
--- a/install_ocl_plugins.sh
+++ b/install_ocl_plugins.sh
@@ -1,13 +1,16 @@
-plugins_dir=`grep miner_plugin_dir grin-miner.toml |  cut -d "\"" -f2 | cut -d "\"" -f1`
-if [ -z "$plugins_dir" ];
-	then plugins_dir="target/debug/plugins"
+plugins_dir=$(egrep '^miner_plugin_dir' grin-miner.toml | awk '{ print $NF }' | xargs echo)
+if [ -z "$plugins_dir" ]; then
+	plugins_dir="target/debug/plugins"
 fi
+
+# Install ocl_cuckatoo
 cd ocl_cuckatoo
 cargo build --release
 cd ..
 cp target/release/libocl_cuckatoo.so $plugins_dir/ocl_cuckatoo.cuckooplugin
+
+# Install ocl_cuckaroo
 cd ocl_cuckaroo
 cargo build --release
 cd ..
 cp target/release/libocl_cuckaroo.so $plugins_dir/ocl_cuckaroo.cuckooplugin
-


### PR DESCRIPTION
As it stands, when `grin-miner.toml` has a commented out `miner_plugin_dir`, the `install_ocl_plugins.sh` script incorrectly picks it up and tries to place the `libocl_cuckatoo.so` and `libocl_cuckaroo.so` into the wrong directory.

This patch addresses that.

Another future improvement I'd recommend to `install_col_plugin.sh` is to detect if the host is actually running Linux and pay attention to the extension of the shared object as on OSX we end up with `.dylib`.