### PR TITLE
Make `install_ocl_plugins` create plugins dir

### DIFF
--- a/install_ocl_plugins.sh
+++ b/install_ocl_plugins.sh
@@ -2,6 +2,7 @@ plugins_dir=$(egrep '^miner_plugin_dir' grin-miner.toml | awk '{ print $NF }' | 
 if [ -z "$plugins_dir" ]; then
 	plugins_dir="target/debug/plugins"
 fi
+mkdir -p "$plugins_dir";
 
 # Install ocl_cuckatoo
 cd ocl_cuckatoo


### PR DESCRIPTION
I went straight to compiling for release, which meant that `target/debug/plugins` did not exist and the script errored out.