### PR TITLE
Changed default CPU-mining plugin AVX2 -> COMPAT_29 - grin-miner.toml

### DIFF
--- a/grin-miner.toml
+++ b/grin-miner.toml
@@ -77,7 +77,7 @@ stratum_server_tls_enabled = false
 # The fastest cpu algorithm, but consumes the most memory
 
 [[mining.miner_plugin_config]]
-plugin_name = "cuckaroo_cpu_avx2_29"
+plugin_name = "cuckaroo_cpu_compat_29"
 [mining.miner_plugin_config.parameters]
 nthreads = 4
 


### PR DESCRIPTION
Changed the default cpu-mining plugin back to original 'cuckaroo_cpu_compat_29'. It was changed to avx2 in commit 8669c2450afca939e20aebecbb0b5b748707a0a9. 

Plugin for Avx2-supported CPUs is introduced in next section of the config-file. See https://github.com/mimblewimble/grin-miner/issues/152 