### PR TITLE
Use cuckaroo_cpu_compat_29 as the default mining strategy

### DIFF
--- a/grin-miner.toml
+++ b/grin-miner.toml
@@ -77,7 +77,7 @@ stratum_server_tls_enabled = false
 # The fastest cpu algorithm, but consumes the most memory
 
 [[mining.miner_plugin_config]]
-plugin_name = "cuckaroo_cpu_avx2_29"
+plugin_name = "cuckaroo_cpu_compat_29"
 [mining.miner_plugin_config.parameters]
 nthreads = 4
 


### PR DESCRIPTION
I think this may have accidentally made it into a prior merge. Seems like we don't want to use avx based on the surrounding documentation, but cuckaroo_cpu_compat_29 as the default.