### PR TITLE
feat: add OpenCL device compatibility check + fix typo

### DIFF
--- a/ocl_cuckaroo/src/trimmer.rs
+++ b/ocl_cuckaroo/src/trimmer.rs
@@ -89,7 +89,7 @@ impl Trimmer {
 		env::set_var("GPU_SINGLE_ALLOC_PERCENT", "100");
 		env::set_var("GPU_64BIT_ATOMICS", "1");
 		env::set_var("GPU_MAX_WORKGROUP_SIZE", "1024");
-		let platform = find_paltform(platform_name)
+		let platform = find_platform(platform_name)
 			.ok_or::<ocl::Error>("Can't find OpenCL platform".into())?;
 		let p_name = platform.name()?;
 		let device = find_device(&platform, device_id)?;
@@ -429,7 +429,7 @@ fn print_event(name: &str, ev: &Event) {
 #[cfg(not(feature = "profile"))]
 fn print_event(_name: &str, _ev: &Event) {}
 
-fn find_paltform(selector: Option<&str>) -> Option<Platform> {
+fn find_platform(selector: Option<&str>) -> Option<Platform> {
 	match selector {
 		None => Some(Platform::default()),
 		Some(sel) => Platform::list().into_iter().find(|p| {

--- a/ocl_cuckatoo/src/trimmer.rs
+++ b/ocl_cuckatoo/src/trimmer.rs
@@ -29,7 +29,7 @@ impl Trimmer {
 		device_id: Option<usize>,
 		edge_bits: u8,
 	) -> ocl::Result<Trimmer> {
-		let platform = find_paltform(platform_name)
+		let platform = find_platform(platform_name)
 			.ok_or::<ocl::Error>("Can't find OpenCL platform".into())?;
 		let device = find_device(&platform, device_id)?;
 
@@ -147,7 +147,7 @@ impl Trimmer {
 	}
 }
 
-fn find_paltform(selector: Option<&str>) -> Option<Platform> {
+fn find_platform(selector: Option<&str>) -> Option<Platform> {
 	match selector {
 		None => Some(Platform::default()),
 		Some(sel) => Platform::list().into_iter().find(|p| {


### PR DESCRIPTION
This patch adds a compatibility check to the cuckaroo trimmer to check that the targeted OpenCL device can properly handle memory allocation that is required for running the mining algorithm. in case the compatibility test fails, an explanation string is returned instead of letting OpenCL later complain with and error code most people won't understand.

I believe this would help a lot of people that are trying to run cuckaroo on a GPU that cannot handle it, giving them a straight answer to their actual problem.