### PR TITLE
Fix for issue #163

### DIFF
--- a/ocl_cuckatoo/src/trimmer.rs
+++ b/ocl_cuckatoo/src/trimmer.rs
@@ -217,9 +217,9 @@ __kernel  void LeanRound(const u64 v0i, const u64 v1i, const u64 v2i, const u64 
 	const int blocks = NEDGES / 32;
 	const int gid = get_global_id(0);
 	const int lid = get_local_id(0);
+	__local u32 el[256][8];
 
 	{
-		__local u32 el[256][8];
 		int lCount = 0;
 		// what 256 nit block of edges are we processing
 		u64 index = gid;


### PR DESCRIPTION
The local variable was not at kernel function scope as required in the OpenCL spec.
https://www.khronos.org/registry/OpenCL/sdk/2.0/docs/man/xhtml/local.html

Quote:
"if (...) { // example of variable in __local address space but not // declared at __kernel function scope. local float c; // not allowed. }"

Note:
I also had to symlink the ROCm OpenCL lib to build since it wasn't in /usr/lib/ where it's expected.
`sudo ln -s /opt/rocm/opencl/lib/x86_64/libOpenCL.so /usr/lib/libOpenCL.so`