### PR TITLE
Add GitHub Actions Rust CI workflow

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,0 +1,22 @@
+name: Rust
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Build
+      run: cargo build --verbose
+    - name: Run tests
+      run: cargo test --verbose


### PR DESCRIPTION
Add a GitHub Actions workflow to run CI for the Rust project on pushes and pull requests to master. The job runs on ubuntu-latest, sets CARGO_TERM_COLOR=always, checks out the repository (actions/checkout@v3), then runs `cargo build --verbose` and `cargo test --verbose`.